### PR TITLE
Hoist MDX collection and parallelize generate

### DIFF
--- a/public/rss.xml
+++ b/public/rss.xml
@@ -4,7 +4,7 @@
         <title>Matt Hamlin's Blog</title>
         <link>https://matthamlin.me</link>
         <description>Matt Hamlin's Blog</description>
-        <lastBuildDate>Wed, 26 Nov 2025 20:24:48 GMT</lastBuildDate>
+        <lastBuildDate>Wed, 26 Nov 2025 20:40:20 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>Matt by Hand</generator>
         <language>en</language>

--- a/scripts/build/generate-metadata.ts
+++ b/scripts/build/generate-metadata.ts
@@ -1,14 +1,12 @@
 /// <reference types="bun" />
 import topPostPaths from "#/top-posts.json";
 import type { HydratedFrontmatter } from "#/types";
-import { collectMetadata, getMDXFiles } from "./collect-metadata";
 
 let metadataPath = "./src/metadata.gen.ts";
 
-export async function generateMetadata() {
-  let mdxFiles = await getMDXFiles();
-
-  let metadata = await collectMetadata(mdxFiles);
+export async function generateMetadata(
+  metadata: Array<HydratedFrontmatter>,
+) {
 
   // metadata.gen.ts:
   // biome-ignore lint/correctness/noUnusedLabels: easy way to collapse related code with a label

--- a/scripts/build/generate-og-images.tsx
+++ b/scripts/build/generate-og-images.tsx
@@ -1,7 +1,7 @@
 /// <reference types="bun" />
 import { generateImage as generateBaseImage } from "pikitia";
+import type { HydratedFrontmatter } from "#/types";
 import imageCacheJSON from "../../image-cache.json";
-import { collectMetadata, getMDXFiles } from "./collect-metadata";
 
 let imageCache = new Map(Object.entries(imageCacheJSON)) as Map<
   string,
@@ -54,10 +54,7 @@ export async function generateImage({
   return pngBuffer;
 }
 
-export async function generateOGImages() {
-  let files = await getMDXFiles();
-
-  let metadata = await collectMetadata(files);
+export async function generateOGImages(metadata: Array<HydratedFrontmatter>) {
 
   for (let meta of metadata) {
     let description =

--- a/scripts/build/generate-rss.tsx
+++ b/scripts/build/generate-rss.tsx
@@ -1,13 +1,11 @@
 import { Feed } from "feed";
 import matter from "gray-matter";
 import type { ReactNode } from "react";
+import type { HydratedFrontmatter } from "#/types";
 import { useMDXComponents as defaultUseMDXComponents } from "#/utils/mdx-components";
-import { collectMetadata, getMDXFiles } from "./collect-metadata";
 import { transformMdx } from "./transform-mdx";
 
-export async function generateRSS() {
-  let mdxFiles = await getMDXFiles();
-  let metadata = await collectMetadata(mdxFiles);
+export async function generateRSS(metadata: Array<HydratedFrontmatter>) {
 
   let feed = new Feed({
     title: "Matt Hamlin's Blog",

--- a/scripts/build/generate.ts
+++ b/scripts/build/generate.ts
@@ -1,11 +1,13 @@
+import { collectMetadata, getMDXFiles } from "./collect-metadata";
 import { generateMetadata } from "./generate-metadata";
 import { generateOGImages } from "./generate-og-images";
 import { generateRSS } from "./generate-rss";
 
-console.log("Generating metadata...");
-await generateMetadata();
-console.log("Generating RSS...");
-await generateRSS();
-console.log("Generating OG images...");
-await generateOGImages();
-console.log("Done!");
+let mdxFiles = await getMDXFiles();
+let metadata = await collectMetadata(mdxFiles);
+
+await Promise.all([
+  generateMetadata(metadata),
+  generateRSS(metadata),
+  generateOGImages(metadata),
+]);

--- a/src/collections/recent-posts.gen.ts
+++ b/src/collections/recent-posts.gen.ts
@@ -26,7 +26,7 @@ export let recentPosts: Array<HydratedFrontmatter> = [
     "ogImage": "/og-images/things-leaders-should-never-do.png",
     "blueskyPostUri": "",
     "location": "Stamford, CT",
-    "lastModified": 1764186098000
+    "lastModified": 1764188765000
   },
   {
     "title": "In Review - I, Robot",

--- a/src/metadata.gen.ts
+++ b/src/metadata.gen.ts
@@ -27,7 +27,7 @@ export let metadata: Array<HydratedFrontmatter> = [
     "ogImage": "/og-images/things-leaders-should-never-do.png",
     "blueskyPostUri": "",
     "location": "Stamford, CT",
-    "lastModified": 1764186098000
+    "lastModified": 1764188765000
   },
   {
     "title": "Tip: Secrets for Cloudflare Workers",


### PR DESCRIPTION
## Summary

- Moved MDX file collection and metadata generation to the top-level generate.ts script
- Each generate function now accepts pre-computed metadata as a parameter
- All three generate functions now run in parallel using Promise.all() instead of sequentially

This eliminates duplicate file I/O operations and improves build performance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)